### PR TITLE
fix: don't let Modbus framing hijack Actron messages

### DIFF
--- a/components/actron485/actron485_climate.cpp
+++ b/components/actron485/actron485_climate.cpp
@@ -99,8 +99,12 @@ void Actron485Climate::power_off() {
     actron_controller.setSystemOn(false);
 }
 
-void Actron485Climate::power_toggle() { 
+void Actron485Climate::power_toggle() {
     actron_controller.setSystemOn(!actron_controller.getSystemOn());
+}
+
+Actron485::Controller *Actron485Climate::get_controller() {
+    return &actron_controller;
 }
 
 void Actron485Climate::add_zone(int number, Actron485ZoneFan *fan) {

--- a/components/actron485/actron485_climate.h
+++ b/components/actron485/actron485_climate.h
@@ -92,6 +92,20 @@ class Actron485Climate : public climate::Climate, public Component {
         void power_off();
         void power_toggle();
 
+        // Accessor for external components (e.g. actron485_api) that need to
+        // read/write the underlying Actron485 controller state directly.
+        Actron485::Controller *get_controller();
+
+        // Snapshot helpers for the API layer to read zone fan assignments
+        // without re-plumbing them from YAML.
+        Actron485ZoneFan *get_zone_fan(int number) const {
+            return (number >= 1 && number <= 8) ? zones_[number - 1] : nullptr;
+        }
+        Actron485ZoneClimate *get_zone_climate(int number) const {
+            return (number >= 1 && number <= 8) ? zone_climates_[number - 1] : nullptr;
+        }
+        bool has_ultima() const { return has_ultima_; }
+
     protected:
         InternalGPIOPin *we_pin_ = NULL;
         UARTStream stream_;

--- a/components/actron485_api/__init__.py
+++ b/components/actron485_api/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_ID
 CONF_CLIMATE_ID = "climate_id"
 CONF_AUTH_TOKEN = "auth_token"
 CONF_SENSOR_STALE_TIMEOUT = "sensor_stale_timeout"
+CONF_DEMO_MODE = "demo_mode"
 
 AUTO_LOAD = ["web_server_base"]
 DEPENDENCIES = ["web_server_base", "climate"]
@@ -28,6 +29,10 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(
             CONF_SENSOR_STALE_TIMEOUT, default="10min"
         ): cv.positive_time_period_milliseconds,
+        # If true, the API serves simulated state and drops any outbound
+        # RS485 writes so the firmware can run safely on a bench T-CAN485
+        # with no bus connection. Intended for mobile app end-to-end tests.
+        cv.Optional(CONF_DEMO_MODE, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -43,6 +48,7 @@ async def to_code(config):
         cg.add(var.set_auth_token(config[CONF_AUTH_TOKEN]))
 
     cg.add(var.set_sensor_stale_timeout_ms(config[CONF_SENSOR_STALE_TIMEOUT]))
+    cg.add(var.set_demo_mode(config[CONF_DEMO_MODE]))
 
     # Pulled in by ESPHome's json component transitively, but declare
     # explicitly to make the dependency obvious and pin a major version.

--- a/components/actron485_api/__init__.py
+++ b/components/actron485_api/__init__.py
@@ -1,0 +1,49 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import web_server_base
+from esphome.const import CONF_ID
+
+CONF_CLIMATE_ID = "climate_id"
+CONF_AUTH_TOKEN = "auth_token"
+CONF_SENSOR_STALE_TIMEOUT = "sensor_stale_timeout"
+
+AUTO_LOAD = ["web_server_base"]
+DEPENDENCIES = ["web_server_base", "climate"]
+CODEOWNERS = ["@wojt-janowski"]
+
+actron485_api_ns = cg.esphome_ns.namespace("actron485_api")
+Actron485Api = actron485_api_ns.class_("Actron485Api", cg.Component)
+
+actron485_ns = cg.esphome_ns.namespace("actron485")
+Actron485Climate = actron485_ns.class_("Actron485Climate")
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(Actron485Api),
+        cv.Required(CONF_CLIMATE_ID): cv.use_id(Actron485Climate),
+        cv.Optional(CONF_AUTH_TOKEN): cv.string_strict,
+        # Auto-release wall-controller role for a zone if no
+        # /temperature POST is received within this window. Set to 0 to
+        # disable the safety.
+        cv.Optional(
+            CONF_SENSOR_STALE_TIMEOUT, default="10min"
+        ): cv.positive_time_period_milliseconds,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    climate = await cg.get_variable(config[CONF_CLIMATE_ID])
+    cg.add(var.set_climate(climate))
+
+    if CONF_AUTH_TOKEN in config:
+        cg.add(var.set_auth_token(config[CONF_AUTH_TOKEN]))
+
+    cg.add(var.set_sensor_stale_timeout_ms(config[CONF_SENSOR_STALE_TIMEOUT]))
+
+    # Pulled in by ESPHome's json component transitively, but declare
+    # explicitly to make the dependency obvious and pin a major version.
+    cg.add_library("bblanchon/ArduinoJson", "^7.0.0")

--- a/components/actron485_api/actron485_api.cpp
+++ b/components/actron485_api/actron485_api.cpp
@@ -5,6 +5,8 @@
 
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/preferences.h"
 
 #include <esp_http_server.h>
 #include <ArduinoJson.h>
@@ -90,7 +92,58 @@ void Actron485Api::setup() {
   }
   handler_ = new Actron485ApiHandler(this);
   base->add_handler(handler_);
+  this->load_zone_names_();
   ESP_LOGCONFIG(TAG, "Actron485 API mounted at /api/v1/* on port %u", base->get_port());
+}
+
+void Actron485Api::load_zone_names_() {
+  // Stable hash for the preference slot. Keep this constant across
+  // firmware builds or you'll lose saved names.
+  uint32_t hash = fnv1_hash(std::string("actron485_api_zone_names_v1"));
+  zone_names_pref_ = global_preferences->make_preference<ZoneNamesBlob>(hash);
+  ZoneNamesBlob blob{};
+  if (zone_names_pref_.load(&blob)) {
+    for (int i = 0; i < 8; i++) {
+      // Defensive: ensure null-termination even if flash was corrupted.
+      blob.names[i][ZONE_NAME_MAX] = '\0';
+      zone_name_overrides_[i] = std::string(blob.names[i]);
+    }
+  }
+}
+
+void Actron485Api::save_zone_names_() {
+  ZoneNamesBlob blob{};
+  for (int i = 0; i < 8; i++) {
+    const auto &s = zone_name_overrides_[i];
+    size_t n = std::min(s.size(), ZONE_NAME_MAX);
+    memcpy(blob.names[i], s.data(), n);
+    blob.names[i][n] = '\0';
+  }
+  zone_names_pref_.save(&blob);
+  global_preferences->sync();
+}
+
+std::string Actron485Api::get_zone_display_name(int zone) {
+  if (zone < 1 || zone > 8) return std::string();
+  const auto &override_name = zone_name_overrides_[zone - 1];
+  if (!override_name.empty()) return override_name;
+  if (auto *zc = climate_->get_zone_climate(zone)) {
+    auto s = std::string(zc->get_name());
+    if (!s.empty()) return s;
+  }
+  if (auto *zf = climate_->get_zone_fan(zone)) {
+    auto s = std::string(zf->get_name());
+    if (!s.empty()) return s;
+  }
+  return "Zone " + std::to_string(zone);
+}
+
+bool Actron485Api::set_zone_name_override(uint8_t zone, const std::string &name) {
+  if (zone < 1 || zone > 8) return false;
+  if (name.size() > ZONE_NAME_MAX) return false;
+  zone_name_overrides_[zone - 1] = name;
+  this->save_zone_names_();
+  return true;
 }
 
 void Actron485Api::dump_config() {
@@ -157,20 +210,7 @@ std::string Actron485Api::build_state_json() {
   for (int i = 1; i <= 8; i++) {
     JsonObject z = zones.add<JsonObject>();
     z["number"] = i;
-    // Names come from the YAML's climate.zones[*].name, which ESPHome
-    // stores as the zone fan entity name. Prefer the Ultima zone-climate
-    // name if available (that's what users will interact with in Que mode),
-    // fall back to the zone fan, final fall-back to "Zone N".
-    std::string name;
-    if (auto *zc = climate_->get_zone_climate(i)) {
-      name = std::string(zc->get_name());
-    } else if (auto *zf = climate_->get_zone_fan(i)) {
-      name = std::string(zf->get_name());
-    }
-    if (name.empty()) {
-      name = "Zone " + std::to_string(i);
-    }
-    z["name"] = name;
+    z["name"] = this->get_zone_display_name(i);
     z["on"] = c->getZoneOn(i);
     z["damper"] = c->getZoneDamperPosition(i);
     z["control"] = c->getControlZone(i);
@@ -323,6 +363,10 @@ void Actron485ApiHandler::handleRequest(AsyncWebServerRequest *request) {
         handle_zone_temperature_(request, zone, body);
         return;
       }
+      if (subpath == "name") {
+        handle_zone_name_(request, zone, body);
+        return;
+      }
       send_error_(request, 404, "not_found");
       return;
     }
@@ -341,6 +385,13 @@ void Actron485ApiHandler::handle_info_(AsyncWebServerRequest *request) {
   root["has_ultima"] = parent_->climate()->has_ultima();
   root["zone_count"] = 8;
   root["uptime_ms"] = (unsigned long) millis();
+  // Static zone metadata — safe to return even when the RS485 bus is silent.
+  JsonArray zones = root["zones"].to<JsonArray>();
+  for (int i = 1; i <= 8; i++) {
+    JsonObject z = zones.add<JsonObject>();
+    z["number"] = i;
+    z["name"] = parent_->get_zone_display_name(i);
+  }
 
   std::string out;
   serializeJson(doc, out);
@@ -471,6 +522,30 @@ void Actron485ApiHandler::handle_zone_temperature_(AsyncWebServerRequest *reques
   parent_->controller()->setZoneCurrentTemperature((uint8_t) zone, t);
   parent_->note_zone_temperature_update((uint8_t) zone);
   send_json_(request, 202, "{\"status\":\"queued\"}");
+}
+
+// POST /api/v1/zones/{n}/name  {"name": "Living Room"}
+// Persists a display-name override for the zone to flash (ESPHome
+// preferences). The override is returned in /info and /state in place of
+// the yaml-configured name. Pass an empty string to clear the override.
+// Applies immediately (returns 200, not 202 — it's local state, not an
+// RS485 command).
+void Actron485ApiHandler::handle_zone_name_(AsyncWebServerRequest *request, int zone, const std::string &body) {
+  if (zone < 1 || zone > 8) { send_error_(request, 400, "invalid_zone"); return; }
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
+  if (!doc["name"].is<const char *>()) { send_error_(request, 400, "missing_name"); return; }
+  std::string name = doc["name"].as<const char *>();
+  if (!parent_->set_zone_name_override((uint8_t) zone, name)) {
+    send_error_(request, 400, "name_too_long");
+    return;
+  }
+  JsonDocument resp;
+  resp["number"] = zone;
+  resp["name"] = parent_->get_zone_display_name(zone);
+  std::string body_out;
+  serializeJson(resp, body_out);
+  send_json_(request, 200, body_out);
 }
 
 }  // namespace actron485_api

--- a/components/actron485_api/actron485_api.cpp
+++ b/components/actron485_api/actron485_api.cpp
@@ -7,6 +7,9 @@
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
+#include "esphome/components/actron485/utilities.h"
+#include "esphome/components/actron485/zone_fan.h"
+#include "esphome/components/actron485/zone_climate.h"
 
 #include <esp_http_server.h>
 #include <ArduinoJson.h>
@@ -229,6 +232,44 @@ void Actron485Api::demo_tick_() {
     sum += demo_zone_current_[i];
   }
   demo_current_ = sum / 8.0f;
+
+  // Also push our simulated state into the ESPHome Climate and fan/zone
+  // entities so the built-in web UI and Home Assistant integration stop
+  // showing NaNs. Without this, those entities still poll the real (and
+  // silent) RS485 controller and publish nothing. Rate-limited to ~1 Hz.
+  if (now - demo_last_publish_ms_ < 1000) return;
+  demo_last_publish_ms_ = now;
+  using esphome::actron485::Converter;
+  namespace clm = esphome::climate;
+
+  climate_->current_temperature = demo_current_;
+  climate_->target_temperature = demo_setpoint_;
+  climate_->mode = demo_system_on_
+                      ? Converter::to_climate_mode(demo_op_mode_)
+                      : clm::CLIMATE_MODE_OFF;
+  climate_->fan_mode = Converter::to_fan_mode(demo_fan_);
+  Actron485::CompressorMode cmode = Actron485::CompressorMode::Idle;
+  if (demo_system_on_) {
+    if (demo_op_mode_ == Actron485::OperatingMode::Cool) cmode = Actron485::CompressorMode::Cooling;
+    else if (demo_op_mode_ == Actron485::OperatingMode::Heat) cmode = Actron485::CompressorMode::Heating;
+  }
+  climate_->action = demo_system_on_
+                        ? Converter::to_climate_action(cmode, demo_op_mode_)
+                        : clm::CLIMATE_ACTION_OFF;
+  climate_->publish_state();
+
+  for (int i = 1; i <= 8; i++) {
+    if (auto *zf = climate_->get_zone_fan(i)) {
+      zf->state = demo_zone_on_[i - 1];
+      zf->publish_state();
+    }
+    if (auto *zc = climate_->get_zone_climate(i)) {
+      zc->current_temperature = demo_zone_current_[i - 1];
+      zc->target_temperature = demo_zone_setpoint_[i - 1];
+      zc->mode = demo_zone_on_[i - 1] ? climate_->mode : clm::CLIMATE_MODE_OFF;
+      zc->publish_state();
+    }
+  }
 }
 
 void Actron485Api::note_zone_temperature_update(uint8_t zone) {

--- a/components/actron485_api/actron485_api.cpp
+++ b/components/actron485_api/actron485_api.cpp
@@ -165,16 +165,38 @@ void Actron485Api::dump_config() {
 
 // -------- Write wrappers: controller in normal mode, local state in demo --------
 
+// In demo mode the apply_* writers mutate the ESPHome Climate/fan
+// entities directly, then publish. This keeps the web UI, Home Assistant
+// integration, and the REST API in sync — no matter who triggered the
+// change (API POST, web UI drag, HA automation), everyone sees it.
 void Actron485Api::apply_system_on(bool on) {
-  if (demo_mode_) { demo_system_on_ = on; return; }
+  if (demo_mode_) {
+    demo_system_on_ = on;
+    climate_->mode = on ? actron485::Converter::to_climate_mode(demo_op_mode_)
+                        : climate::CLIMATE_MODE_OFF;
+    climate_->publish_state();
+    return;
+  }
   controller()->setSystemOn(on);
 }
 void Actron485Api::apply_operating_mode(Actron485::OperatingMode mode) {
-  if (demo_mode_) { demo_op_mode_ = mode; return; }
+  if (demo_mode_) {
+    demo_op_mode_ = mode;
+    // Off/OffCool/OffHeat/OffAuto map to CLIMATE_MODE_OFF per Converter.
+    climate_->mode = actron485::Converter::to_climate_mode(mode);
+    demo_system_on_ = (climate_->mode != climate::CLIMATE_MODE_OFF);
+    climate_->publish_state();
+    return;
+  }
   controller()->setOperatingMode(mode);
 }
 void Actron485Api::apply_fan_speed(Actron485::FanMode mode) {
-  if (demo_mode_) { demo_fan_ = mode; return; }
+  if (demo_mode_) {
+    demo_fan_ = mode;
+    climate_->fan_mode = actron485::Converter::to_fan_mode(mode);
+    climate_->publish_state();
+    return;
+  }
   controller()->setFanSpeed(mode);
 }
 void Actron485Api::apply_continuous_fan(bool on) {
@@ -182,17 +204,36 @@ void Actron485Api::apply_continuous_fan(bool on) {
   controller()->setContinuousFanMode(on);
 }
 void Actron485Api::apply_master_setpoint(double temperature) {
-  if (demo_mode_) { demo_setpoint_ = (float) temperature; return; }
+  if (demo_mode_) {
+    demo_setpoint_ = (float) temperature;
+    climate_->target_temperature = (float) temperature;
+    climate_->publish_state();
+    return;
+  }
   controller()->setMasterSetpoint(temperature);
 }
 void Actron485Api::apply_zone_on(uint8_t zone, bool on) {
   if (zone < 1 || zone > 8) return;
-  if (demo_mode_) { demo_zone_on_[zone - 1] = on; return; }
+  if (demo_mode_) {
+    demo_zone_on_[zone - 1] = on;
+    if (auto *zf = climate_->get_zone_fan(zone)) {
+      zf->state = on;
+      zf->publish_state();
+    }
+    return;
+  }
   controller()->setZoneOn(zone, on);
 }
 void Actron485Api::apply_zone_setpoint(uint8_t zone, double temperature) {
   if (zone < 1 || zone > 8) return;
-  if (demo_mode_) { demo_zone_setpoint_[zone - 1] = (float) temperature; return; }
+  if (demo_mode_) {
+    demo_zone_setpoint_[zone - 1] = (float) temperature;
+    if (auto *zc = climate_->get_zone_climate(zone)) {
+      zc->target_temperature = (float) temperature;
+      zc->publish_state();
+    }
+    return;
+  }
   controller()->setZoneSetpointTemperatureCustom(zone, temperature, false);
 }
 void Actron485Api::apply_zone_control(uint8_t zone, bool enabled) {
@@ -202,7 +243,14 @@ void Actron485Api::apply_zone_control(uint8_t zone, bool enabled) {
 }
 void Actron485Api::apply_zone_current_temperature(uint8_t zone, double temperature) {
   if (zone < 1 || zone > 8) return;
-  if (demo_mode_) { demo_zone_current_[zone - 1] = (float) temperature; return; }
+  if (demo_mode_) {
+    demo_zone_current_[zone - 1] = (float) temperature;
+    if (auto *zc = climate_->get_zone_climate(zone)) {
+      zc->current_temperature = (float) temperature;
+      zc->publish_state();
+    }
+    return;
+  }
   controller()->setZoneCurrentTemperature(zone, temperature);
 }
 
@@ -211,17 +259,56 @@ bool Actron485Api::state_receiving_data() {
   return controller()->receivingData();
 }
 
-// Drift zone currents toward their setpoints (or toward master setpoint if the
-// zone has no setpoint set / isn't controlled), so the mobile app sees live-ish
-// movement in demo mode. Master current is the mean of zone currents.
+// Drift zone currents toward their setpoints and publish the simulator's
+// state. The Climate/fan entities are authoritative for user-visible
+// settings (setpoint, mode, fan, zone on/off) — we READ them at the start
+// of each tick so web-UI or Home-Assistant changes stick, and only WRITE
+// back the fields we simulate (current_temperature, action).
 void Actron485Api::demo_tick_() {
+  using esphome::actron485::Converter;
+  namespace clm = esphome::climate;
+
   unsigned long now = millis();
   if (demo_last_tick_ms_ == 0) { demo_last_tick_ms_ = now; return; }
   float dt = (now - demo_last_tick_ms_) / 1000.0f;
   demo_last_tick_ms_ = now;
   if (dt <= 0) return;
 
-  const float rate = 0.05f;  // °C per second toward target
+  // 1) Sync *from* the Climate entity so user changes from the web UI /
+  //    HA propagate into our demo state. Also seed defaults the first
+  //    time through if the entity hasn't been published yet.
+  if (!std::isnan(climate_->target_temperature)) {
+    demo_setpoint_ = climate_->target_temperature;
+  } else {
+    climate_->target_temperature = demo_setpoint_;
+  }
+  if (climate_->mode == clm::CLIMATE_MODE_OFF) {
+    demo_system_on_ = false;
+  } else {
+    demo_system_on_ = true;
+    demo_op_mode_ = Converter::to_actron_operating_mode(climate_->mode);
+  }
+  if (climate_->fan_mode.has_value()) {
+    demo_fan_ = Converter::to_actron_fan_mode(*climate_->fan_mode);
+  } else {
+    climate_->fan_mode = Converter::to_fan_mode(demo_fan_);
+  }
+
+  for (int i = 1; i <= 8; i++) {
+    if (auto *zf = climate_->get_zone_fan(i)) {
+      demo_zone_on_[i - 1] = zf->state;
+    }
+    if (auto *zc = climate_->get_zone_climate(i)) {
+      if (!std::isnan(zc->target_temperature)) {
+        demo_zone_setpoint_[i - 1] = zc->target_temperature;
+      } else {
+        zc->target_temperature = demo_zone_setpoint_[i - 1];
+      }
+    }
+  }
+
+  // 2) Drift simulated currents toward per-zone targets.
+  const float rate = 0.05f;  // °C per second
   float sum = 0;
   for (int i = 0; i < 8; i++) {
     float target = demo_zone_setpoint_[i];
@@ -233,21 +320,12 @@ void Actron485Api::demo_tick_() {
   }
   demo_current_ = sum / 8.0f;
 
-  // Also push our simulated state into the ESPHome Climate and fan/zone
-  // entities so the built-in web UI and Home Assistant integration stop
-  // showing NaNs. Without this, those entities still poll the real (and
-  // silent) RS485 controller and publish nothing. Rate-limited to ~1 Hz.
+  // 3) Publish at most once per second — cheap UI refresh rate, avoids
+  //    spamming the ESPHome subscription machinery.
   if (now - demo_last_publish_ms_ < 1000) return;
   demo_last_publish_ms_ = now;
-  using esphome::actron485::Converter;
-  namespace clm = esphome::climate;
 
   climate_->current_temperature = demo_current_;
-  climate_->target_temperature = demo_setpoint_;
-  climate_->mode = demo_system_on_
-                      ? Converter::to_climate_mode(demo_op_mode_)
-                      : clm::CLIMATE_MODE_OFF;
-  climate_->fan_mode = Converter::to_fan_mode(demo_fan_);
   Actron485::CompressorMode cmode = Actron485::CompressorMode::Idle;
   if (demo_system_on_) {
     if (demo_op_mode_ == Actron485::OperatingMode::Cool) cmode = Actron485::CompressorMode::Cooling;
@@ -259,16 +337,12 @@ void Actron485Api::demo_tick_() {
   climate_->publish_state();
 
   for (int i = 1; i <= 8; i++) {
-    if (auto *zf = climate_->get_zone_fan(i)) {
-      zf->state = demo_zone_on_[i - 1];
-      zf->publish_state();
-    }
     if (auto *zc = climate_->get_zone_climate(i)) {
       zc->current_temperature = demo_zone_current_[i - 1];
-      zc->target_temperature = demo_zone_setpoint_[i - 1];
-      zc->mode = demo_zone_on_[i - 1] ? climate_->mode : clm::CLIMATE_MODE_OFF;
       zc->publish_state();
     }
+    // Zone fans are binary and already publish themselves on user toggle;
+    // no simulated "action" to republish.
   }
 }
 

--- a/components/actron485_api/actron485_api.cpp
+++ b/components/actron485_api/actron485_api.cpp
@@ -157,6 +157,20 @@ std::string Actron485Api::build_state_json() {
   for (int i = 1; i <= 8; i++) {
     JsonObject z = zones.add<JsonObject>();
     z["number"] = i;
+    // Names come from the YAML's climate.zones[*].name, which ESPHome
+    // stores as the zone fan entity name. Prefer the Ultima zone-climate
+    // name if available (that's what users will interact with in Que mode),
+    // fall back to the zone fan, final fall-back to "Zone N".
+    std::string name;
+    if (auto *zc = climate_->get_zone_climate(i)) {
+      name = std::string(zc->get_name());
+    } else if (auto *zf = climate_->get_zone_fan(i)) {
+      name = std::string(zf->get_name());
+    }
+    if (name.empty()) {
+      name = "Zone " + std::to_string(i);
+    }
+    z["name"] = name;
     z["on"] = c->getZoneOn(i);
     z["damper"] = c->getZoneDamperPosition(i);
     z["control"] = c->getControlZone(i);

--- a/components/actron485_api/actron485_api.cpp
+++ b/components/actron485_api/actron485_api.cpp
@@ -456,6 +456,7 @@ void Actron485ApiHandler::handleRequest(AsyncWebServerRequest *request) {
     if (url == "/api/v1/mode") { handle_mode_(request, body); return; }
     if (url == "/api/v1/fan") { handle_fan_(request, body); return; }
     if (url == "/api/v1/setpoint") { handle_setpoint_(request, body); return; }
+    if (url == "/api/v1/demo") { handle_demo_(request, body); return; }
 
     const std::string zones_prefix = "/api/v1/zones/";
     if (url.rfind(zones_prefix, 0) == 0) {
@@ -512,6 +513,31 @@ void Actron485ApiHandler::handle_info_(AsyncWebServerRequest *request) {
 
   std::string out;
   serializeJson(doc, out);
+  send_json_(request, 200, out);
+}
+
+// POST /api/v1/demo  {"enabled": bool}
+// Toggles the firmware's demo simulator at runtime. SESSION-ONLY — a reboot
+// restores whatever the YAML was flashed with. Intended as a dev switch so
+// the mobile app can flip between simulated and real state without
+// reflashing. Returns {"demo": <new state>}.
+void Actron485ApiHandler::handle_demo_(AsyncWebServerRequest *request, const std::string &body) {
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
+  if (!doc["enabled"].is<bool>()) { send_error_(request, 400, "missing_enabled"); return; }
+  bool enabled = doc["enabled"].as<bool>();
+  if (enabled != parent_->demo_mode()) {
+    if (enabled) {
+      ESP_LOGW(TAG, "Switching to DEMO mode at runtime (session-only)");
+    } else {
+      ESP_LOGI(TAG, "Exiting DEMO mode at runtime");
+    }
+    parent_->set_demo_mode(enabled);
+  }
+  JsonDocument resp;
+  resp["demo"] = parent_->demo_mode();
+  std::string out;
+  serializeJson(resp, out);
   send_json_(request, 200, out);
 }
 

--- a/components/actron485_api/actron485_api.cpp
+++ b/components/actron485_api/actron485_api.cpp
@@ -165,38 +165,30 @@ void Actron485Api::dump_config() {
 
 // -------- Write wrappers: controller in normal mode, local state in demo --------
 
-// In demo mode the apply_* writers mutate the ESPHome Climate/fan
-// entities directly, then publish. This keeps the web UI, Home Assistant
-// integration, and the REST API in sync — no matter who triggered the
-// change (API POST, web UI drag, HA automation), everyone sees it.
+// In demo mode the apply_* writers update only demo_* state (httpd
+// thread). They deliberately DO NOT call climate_->publish_state() or
+// otherwise poke ESPHome entities here — that has to happen on the main
+// loop thread. demo_tick() runs at 1 Hz, picks up demo_* changes, syncs
+// them into the Climate/fan entities and publishes. Calling publish_state
+// from the httpd task serialized rapid-fire writes, which made the httpd
+// task start returning 503s and eventually triggered the task watchdog.
 void Actron485Api::apply_system_on(bool on) {
-  if (demo_mode_) {
-    demo_system_on_ = on;
-    climate_->mode = on ? actron485::Converter::to_climate_mode(demo_op_mode_)
-                        : climate::CLIMATE_MODE_OFF;
-    climate_->publish_state();
-    return;
-  }
+  if (demo_mode_) { demo_system_on_ = on; return; }
   controller()->setSystemOn(on);
 }
 void Actron485Api::apply_operating_mode(Actron485::OperatingMode mode) {
   if (demo_mode_) {
     demo_op_mode_ = mode;
-    // Off/OffCool/OffHeat/OffAuto map to CLIMATE_MODE_OFF per Converter.
-    climate_->mode = actron485::Converter::to_climate_mode(mode);
-    demo_system_on_ = (climate_->mode != climate::CLIMATE_MODE_OFF);
-    climate_->publish_state();
+    demo_system_on_ = (mode != Actron485::OperatingMode::Off &&
+                        mode != Actron485::OperatingMode::OffAuto &&
+                        mode != Actron485::OperatingMode::OffCool &&
+                        mode != Actron485::OperatingMode::OffHeat);
     return;
   }
   controller()->setOperatingMode(mode);
 }
 void Actron485Api::apply_fan_speed(Actron485::FanMode mode) {
-  if (demo_mode_) {
-    demo_fan_ = mode;
-    climate_->fan_mode = actron485::Converter::to_fan_mode(mode);
-    climate_->publish_state();
-    return;
-  }
+  if (demo_mode_) { demo_fan_ = mode; return; }
   controller()->setFanSpeed(mode);
 }
 void Actron485Api::apply_continuous_fan(bool on) {
@@ -204,36 +196,17 @@ void Actron485Api::apply_continuous_fan(bool on) {
   controller()->setContinuousFanMode(on);
 }
 void Actron485Api::apply_master_setpoint(double temperature) {
-  if (demo_mode_) {
-    demo_setpoint_ = (float) temperature;
-    climate_->target_temperature = (float) temperature;
-    climate_->publish_state();
-    return;
-  }
+  if (demo_mode_) { demo_setpoint_ = (float) temperature; return; }
   controller()->setMasterSetpoint(temperature);
 }
 void Actron485Api::apply_zone_on(uint8_t zone, bool on) {
   if (zone < 1 || zone > 8) return;
-  if (demo_mode_) {
-    demo_zone_on_[zone - 1] = on;
-    if (auto *zf = climate_->get_zone_fan(zone)) {
-      zf->state = on;
-      zf->publish_state();
-    }
-    return;
-  }
+  if (demo_mode_) { demo_zone_on_[zone - 1] = on; return; }
   controller()->setZoneOn(zone, on);
 }
 void Actron485Api::apply_zone_setpoint(uint8_t zone, double temperature) {
   if (zone < 1 || zone > 8) return;
-  if (demo_mode_) {
-    demo_zone_setpoint_[zone - 1] = (float) temperature;
-    if (auto *zc = climate_->get_zone_climate(zone)) {
-      zc->target_temperature = (float) temperature;
-      zc->publish_state();
-    }
-    return;
-  }
+  if (demo_mode_) { demo_zone_setpoint_[zone - 1] = (float) temperature; return; }
   controller()->setZoneSetpointTemperatureCustom(zone, temperature, false);
 }
 void Actron485Api::apply_zone_control(uint8_t zone, bool enabled) {
@@ -243,14 +216,7 @@ void Actron485Api::apply_zone_control(uint8_t zone, bool enabled) {
 }
 void Actron485Api::apply_zone_current_temperature(uint8_t zone, double temperature) {
   if (zone < 1 || zone > 8) return;
-  if (demo_mode_) {
-    demo_zone_current_[zone - 1] = (float) temperature;
-    if (auto *zc = climate_->get_zone_climate(zone)) {
-      zc->current_temperature = (float) temperature;
-      zc->publish_state();
-    }
-    return;
-  }
+  if (demo_mode_) { demo_zone_current_[zone - 1] = (float) temperature; return; }
   controller()->setZoneCurrentTemperature(zone, temperature);
 }
 
@@ -274,35 +240,38 @@ void Actron485Api::demo_tick_() {
   demo_last_tick_ms_ = now;
   if (dt <= 0) return;
 
-  // 1) Sync *from* the Climate entity so user changes from the web UI /
-  //    HA propagate into our demo state. Also seed defaults the first
-  //    time through if the entity hasn't been published yet.
-  if (!std::isnan(climate_->target_temperature)) {
+  // 1) Merge external (web UI / HA) changes into demo_* state. If a
+  //    climate_ field differs from what we last pushed, something else
+  //    moved it — adopt it. Otherwise demo_* is authoritative (possibly
+  //    just written by an API POST on the httpd thread).
+  if (!std::isnan(climate_->target_temperature) &&
+      climate_->target_temperature != demo_last_pub_setpoint_) {
     demo_setpoint_ = climate_->target_temperature;
-  } else {
-    climate_->target_temperature = demo_setpoint_;
   }
-  if (climate_->mode == clm::CLIMATE_MODE_OFF) {
-    demo_system_on_ = false;
-  } else {
-    demo_system_on_ = true;
-    demo_op_mode_ = Converter::to_actron_operating_mode(climate_->mode);
+  int current_mode_int = (int) climate_->mode;
+  if (current_mode_int != demo_last_pub_mode_) {
+    if (climate_->mode == clm::CLIMATE_MODE_OFF) {
+      demo_system_on_ = false;
+    } else {
+      demo_system_on_ = true;
+      demo_op_mode_ = Converter::to_actron_operating_mode(climate_->mode);
+    }
   }
-  if (climate_->fan_mode.has_value()) {
+  int current_fan_int = climate_->fan_mode.has_value() ? (int) *climate_->fan_mode : -1;
+  if (current_fan_int != demo_last_pub_fan_ && climate_->fan_mode.has_value()) {
     demo_fan_ = Converter::to_actron_fan_mode(*climate_->fan_mode);
-  } else {
-    climate_->fan_mode = Converter::to_fan_mode(demo_fan_);
   }
 
   for (int i = 1; i <= 8; i++) {
     if (auto *zf = climate_->get_zone_fan(i)) {
-      demo_zone_on_[i - 1] = zf->state;
+      if (zf->state != demo_last_pub_zone_on_[i - 1]) {
+        demo_zone_on_[i - 1] = zf->state;
+      }
     }
     if (auto *zc = climate_->get_zone_climate(i)) {
-      if (!std::isnan(zc->target_temperature)) {
+      if (!std::isnan(zc->target_temperature) &&
+          zc->target_temperature != demo_last_pub_zone_setpoint_[i - 1]) {
         demo_zone_setpoint_[i - 1] = zc->target_temperature;
-      } else {
-        zc->target_temperature = demo_zone_setpoint_[i - 1];
       }
     }
   }
@@ -321,10 +290,16 @@ void Actron485Api::demo_tick_() {
   demo_current_ = sum / 8.0f;
 
   // 3) Publish at most once per second — cheap UI refresh rate, avoids
-  //    spamming the ESPHome subscription machinery.
+  //    spamming the ESPHome subscription machinery. This is the ONLY
+  //    place we write to climate_/fan/zone entities, and it runs on the
+  //    main loop, so no thread races with httpd handlers.
   if (now - demo_last_publish_ms_ < 1000) return;
   demo_last_publish_ms_ = now;
 
+  climate_->target_temperature = demo_setpoint_;
+  climate_->mode = demo_system_on_ ? Converter::to_climate_mode(demo_op_mode_)
+                                    : clm::CLIMATE_MODE_OFF;
+  climate_->fan_mode = Converter::to_fan_mode(demo_fan_);
   climate_->current_temperature = demo_current_;
   Actron485::CompressorMode cmode = Actron485::CompressorMode::Idle;
   if (demo_system_on_) {
@@ -336,13 +311,25 @@ void Actron485Api::demo_tick_() {
                         : clm::CLIMATE_ACTION_OFF;
   climate_->publish_state();
 
+  // Remember what we just wrote so next tick can detect external changes.
+  demo_last_pub_setpoint_ = demo_setpoint_;
+  demo_last_pub_mode_ = (int) climate_->mode;
+  demo_last_pub_fan_ = climate_->fan_mode.has_value() ? (int) *climate_->fan_mode : -1;
+
   for (int i = 1; i <= 8; i++) {
+    if (auto *zf = climate_->get_zone_fan(i)) {
+      if (zf->state != demo_zone_on_[i - 1]) {
+        zf->state = demo_zone_on_[i - 1];
+        zf->publish_state();
+      }
+      demo_last_pub_zone_on_[i - 1] = zf->state;
+    }
     if (auto *zc = climate_->get_zone_climate(i)) {
+      zc->target_temperature = demo_zone_setpoint_[i - 1];
       zc->current_temperature = demo_zone_current_[i - 1];
       zc->publish_state();
+      demo_last_pub_zone_setpoint_[i - 1] = demo_zone_setpoint_[i - 1];
     }
-    // Zone fans are binary and already publish themselves on user toggle;
-    // no simulated "action" to republish.
   }
 }
 

--- a/components/actron485_api/actron485_api.cpp
+++ b/components/actron485_api/actron485_api.cpp
@@ -206,7 +206,19 @@ void Actron485Api::apply_zone_on(uint8_t zone, bool on) {
 }
 void Actron485Api::apply_zone_setpoint(uint8_t zone, double temperature) {
   if (zone < 1 || zone > 8) return;
-  if (demo_mode_) { demo_zone_setpoint_[zone - 1] = (float) temperature; return; }
+  if (demo_mode_) {
+    // Match the Que master's clamp to master-setpoint ±2 °C window, so
+    // demo state behaves like the real system rather than permitting
+    // arbitrary per-zone values. The real firmware path doesn't need
+    // this — the Actron master does the clamping itself.
+    const float lo = demo_setpoint_ - 2.0f;
+    const float hi = demo_setpoint_ + 2.0f;
+    float clamped = (float) temperature;
+    if (clamped < lo) clamped = lo;
+    if (clamped > hi) clamped = hi;
+    demo_zone_setpoint_[zone - 1] = clamped;
+    return;
+  }
   controller()->setZoneSetpointTemperatureCustom(zone, temperature, false);
 }
 void Actron485Api::apply_zone_control(uint8_t zone, bool enabled) {
@@ -274,6 +286,17 @@ void Actron485Api::demo_tick_() {
         demo_zone_setpoint_[i - 1] = zc->target_temperature;
       }
     }
+  }
+
+  // 1b) Clamp every zone setpoint to the master-setpoint ±2 °C window.
+  //     Mirrors the Que master's behavior: moving the master drags any
+  //     zones that were outside the new window back inside it. In live
+  //     mode the Actron master does this itself; we only need it here.
+  const float zone_lo = demo_setpoint_ - 2.0f;
+  const float zone_hi = demo_setpoint_ + 2.0f;
+  for (int i = 0; i < 8; i++) {
+    if (demo_zone_setpoint_[i] < zone_lo) demo_zone_setpoint_[i] = zone_lo;
+    if (demo_zone_setpoint_[i] > zone_hi) demo_zone_setpoint_[i] = zone_hi;
   }
 
   // 2) Drift simulated currents toward per-zone targets.

--- a/components/actron485_api/actron485_api.cpp
+++ b/components/actron485_api/actron485_api.cpp
@@ -1,0 +1,463 @@
+#include "actron485_api.h"
+
+#include <cstdlib>
+#include <cstring>
+
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+
+#include <esp_http_server.h>
+#include <ArduinoJson.h>
+
+namespace esphome {
+namespace actron485_api {
+
+static const char *const TAG = "actron485_api";
+static const size_t MAX_BODY_BYTES = 4 * 1024;
+
+// ------------ String conversions ------------
+
+static const char *operating_mode_to_string(Actron485::OperatingMode mode) {
+  switch (mode) {
+    case Actron485::OperatingMode::Off: return "off";
+    case Actron485::OperatingMode::OffAuto: return "off_auto";
+    case Actron485::OperatingMode::OffCool: return "off_cool";
+    case Actron485::OperatingMode::OffHeat: return "off_heat";
+    case Actron485::OperatingMode::FanOnly: return "fan_only";
+    case Actron485::OperatingMode::Auto: return "auto";
+    case Actron485::OperatingMode::Cool: return "cool";
+    case Actron485::OperatingMode::Heat: return "heat";
+  }
+  return "unknown";
+}
+
+static bool string_to_operating_mode(const char *s, Actron485::OperatingMode &out) {
+  if (!s) return false;
+  if (!strcmp(s, "off")) { out = Actron485::OperatingMode::Off; return true; }
+  if (!strcmp(s, "fan_only")) { out = Actron485::OperatingMode::FanOnly; return true; }
+  if (!strcmp(s, "auto")) { out = Actron485::OperatingMode::Auto; return true; }
+  if (!strcmp(s, "cool")) { out = Actron485::OperatingMode::Cool; return true; }
+  if (!strcmp(s, "heat")) { out = Actron485::OperatingMode::Heat; return true; }
+  return false;
+}
+
+static const char *fan_mode_to_string(Actron485::FanMode mode) {
+  switch (mode) {
+    case Actron485::FanMode::Off: return "off";
+    case Actron485::FanMode::Low: case Actron485::FanMode::LowContinuous: return "low";
+    case Actron485::FanMode::Medium: case Actron485::FanMode::MediumContinuous: return "medium";
+    case Actron485::FanMode::High: case Actron485::FanMode::HighContinuous: return "high";
+    case Actron485::FanMode::Esp: case Actron485::FanMode::EspContinuous: return "auto";
+  }
+  return "unknown";
+}
+
+static bool string_to_fan_mode(const char *s, Actron485::FanMode &out) {
+  if (!s) return false;
+  if (!strcmp(s, "low")) { out = Actron485::FanMode::Low; return true; }
+  if (!strcmp(s, "medium")) { out = Actron485::FanMode::Medium; return true; }
+  if (!strcmp(s, "high")) { out = Actron485::FanMode::High; return true; }
+  if (!strcmp(s, "auto")) { out = Actron485::FanMode::Esp; return true; }
+  return false;
+}
+
+static const char *compressor_to_string(Actron485::CompressorMode m) {
+  switch (m) {
+    case Actron485::CompressorMode::Idle: return "idle";
+    case Actron485::CompressorMode::Cooling: return "cooling";
+    case Actron485::CompressorMode::Heating: return "heating";
+    default: return "unknown";
+  }
+}
+
+// ================= Actron485Api =================
+
+float Actron485Api::get_setup_priority() const {
+  return setup_priority::LATE;
+}
+
+void Actron485Api::setup() {
+  if (climate_ == nullptr) {
+    ESP_LOGE(TAG, "No climate reference configured; API will not start");
+    this->mark_failed();
+    return;
+  }
+  auto *base = web_server_base::global_web_server_base;
+  if (base == nullptr) {
+    ESP_LOGE(TAG, "web_server_base not available; add web_server: to your YAML");
+    this->mark_failed();
+    return;
+  }
+  handler_ = new Actron485ApiHandler(this);
+  base->add_handler(handler_);
+  ESP_LOGCONFIG(TAG, "Actron485 API mounted at /api/v1/* on port %u", base->get_port());
+}
+
+void Actron485Api::dump_config() {
+  ESP_LOGCONFIG(TAG, "Actron485 API:");
+  ESP_LOGCONFIG(TAG, "  Auth: %s", auth_token_.empty() ? "disabled" : "token");
+  if (sensor_stale_timeout_ms_ == 0) {
+    ESP_LOGCONFIG(TAG, "  Sensor stale timeout: disabled");
+  } else {
+    ESP_LOGCONFIG(TAG, "  Sensor stale timeout: %u ms", sensor_stale_timeout_ms_);
+  }
+}
+
+void Actron485Api::note_zone_temperature_update(uint8_t zone) {
+  if (zone < 1 || zone > 8) return;
+  last_temp_update_ms_[zone - 1] = millis();
+  if (last_temp_update_ms_[zone - 1] == 0) {
+    // millis() can be 0 very early; nudge to 1 so the "never set" sentinel
+    // (zero) still works.
+    last_temp_update_ms_[zone - 1] = 1;
+  }
+}
+
+void Actron485Api::loop() {
+  if (sensor_stale_timeout_ms_ == 0) return;
+  unsigned long now = millis();
+  // Check at most once per second — cheap but avoids per-tick overhead.
+  if (now - last_stale_check_ms_ < 1000) return;
+  last_stale_check_ms_ = now;
+
+  for (int i = 0; i < 8; i++) {
+    if (last_temp_update_ms_[i] == 0) continue;  // never fed
+    if (now - last_temp_update_ms_[i] < sensor_stale_timeout_ms_) continue;
+    uint8_t zone = (uint8_t) (i + 1);
+    if (controller()->getControlZone(zone)) {
+      ESP_LOGW(TAG, "Zone %u sensor stale (no POST for %lu ms); releasing wall-controller role",
+               zone, now - last_temp_update_ms_[i]);
+      controller()->setControlZone(zone, false);
+    }
+    // Zero it so we don't keep firing. A fresh POST will re-arm.
+    last_temp_update_ms_[i] = 0;
+  }
+}
+
+std::string Actron485Api::build_state_json() {
+  auto *c = controller();
+  JsonDocument doc;
+  auto root = doc.to<JsonObject>();
+
+  // Monotonic ms since boot; the mobile app can compute freshness by diffing
+  // two snapshots' updated_at_ms or comparing to its own request clock.
+  root["updated_at_ms"] = (unsigned long) millis();
+  root["status_received_ms"] = c->statusLastReceivedTime;
+  root["system_on"] = c->getSystemOn();
+  root["mode"] = operating_mode_to_string(c->getOperatingMode());
+  root["fan"] = fan_mode_to_string(c->getFanSpeed());
+  root["fan_running"] = fan_mode_to_string(c->getRunningFanSpeed());
+  root["continuous_fan"] = c->getContinuousFanMode();
+  root["compressor"] = compressor_to_string(c->getCompressorMode());
+  root["setpoint"] = c->getMasterSetpoint();
+  root["current_temperature"] = c->getMasterCurrentTemperature();
+  root["has_ultima"] = climate_->has_ultima();
+
+  JsonArray zones = root["zones"].to<JsonArray>();
+  for (int i = 1; i <= 8; i++) {
+    JsonObject z = zones.add<JsonObject>();
+    z["number"] = i;
+    z["on"] = c->getZoneOn(i);
+    z["damper"] = c->getZoneDamperPosition(i);
+    z["control"] = c->getControlZone(i);
+    if (climate_->has_ultima()) {
+      z["setpoint"] = c->getZoneSetpointTemperature(i);
+      z["current_temperature"] = c->getZoneCurrentTemperature(i);
+    }
+  }
+
+  std::string out;
+  serializeJson(doc, out);
+  return out;
+}
+
+// ================= Handler =================
+
+bool Actron485ApiHandler::canHandle(AsyncWebServerRequest *request) const {
+  char url_buf[AsyncWebServerRequest::URL_BUF_SIZE];
+  auto url = request->url_to(url_buf);
+  // StringRef has no starts_with(); compare via std::string.
+  std::string s(url);
+  return s.rfind("/api/v1/", 0) == 0 || s == "/api/v1";
+}
+
+bool Actron485ApiHandler::authorized_(AsyncWebServerRequest *request) {
+  const std::string &token = parent_->auth_token();
+  if (token.empty()) return true;
+  auto header = request->get_header("Authorization");
+  if (!header.has_value()) return false;
+  const std::string prefix = "Bearer ";
+  const std::string &value = *header;
+  if (value.rfind(prefix, 0) != 0) return false;
+  return value.substr(prefix.size()) == token;
+}
+
+std::string Actron485ApiHandler::read_body_(AsyncWebServerRequest *request) {
+  httpd_req_t *r = *request;
+  size_t content_len = r->content_len;
+  if (content_len == 0 || content_len > MAX_BODY_BYTES) return "";
+
+  std::string body(content_len, '\0');
+  size_t received = 0;
+  while (received < content_len) {
+    int n = httpd_req_recv(r, &body[received], content_len - received);
+    if (n <= 0) return "";
+    received += (size_t) n;
+  }
+  body.resize(received);
+  return body;
+}
+
+void Actron485ApiHandler::add_cors_headers_(AsyncWebServerResponse *response) {
+  // Access-Control-Allow-Origin: * is already added by web_server_base's
+  // DefaultHeaders. We add the method/header list for preflight support.
+  response->addHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  response->addHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+}
+
+// ESPHome's web_server_idf::AsyncWebServerRequest::init_response_ only
+// recognises 200/404/409 and falls through to 500 for everything else
+// (see esphome/components/web_server_idf/web_server_idf.cpp:272). We
+// override the status directly on the underlying IDF handle so codes like
+// 202 Accepted, 400 Bad Request, 401 Unauthorized, 204 No Content work.
+static void override_status(AsyncWebServerRequest *request, int code) {
+  httpd_req_t *r = *request;
+  switch (code) {
+    case 200: httpd_resp_set_status(r, "200 OK"); break;
+    case 202: httpd_resp_set_status(r, "202 Accepted"); break;
+    case 204: httpd_resp_set_status(r, "204 No Content"); break;
+    case 400: httpd_resp_set_status(r, "400 Bad Request"); break;
+    case 401: httpd_resp_set_status(r, "401 Unauthorized"); break;
+    case 404: httpd_resp_set_status(r, "404 Not Found"); break;
+    case 409: httpd_resp_set_status(r, "409 Conflict"); break;
+    default:  httpd_resp_set_status(r, "500 Internal Server Error"); break;
+  }
+}
+
+void Actron485ApiHandler::send_json_(AsyncWebServerRequest *request, int code, const std::string &body) {
+  auto *response = request->beginResponse(code, "application/json", body);
+  add_cors_headers_(response);
+  override_status(request, code);
+  request->send(response);
+}
+
+void Actron485ApiHandler::send_error_(AsyncWebServerRequest *request, int code, const char *message) {
+  std::string body = "{\"error\":\"";
+  body += message;
+  body += "\"}";
+  send_json_(request, code, body);
+}
+
+void Actron485ApiHandler::handleRequest(AsyncWebServerRequest *request) {
+  if (request->method() == HTTP_OPTIONS) {
+    auto *response = request->beginResponse(204, nullptr);
+    add_cors_headers_(response);
+    override_status(request, 204);
+    request->send(response);
+    return;
+  }
+
+  if (!authorized_(request)) {
+    send_error_(request, 401, "unauthorized");
+    return;
+  }
+
+  char url_buf[AsyncWebServerRequest::URL_BUF_SIZE];
+  auto url_ref = request->url_to(url_buf);
+  std::string url(url_ref);
+  http_method method = request->method();
+
+  if (method == HTTP_GET && url == "/api/v1/info") {
+    handle_info_(request);
+    return;
+  }
+  if (method == HTTP_GET && url == "/api/v1/state") {
+    handle_state_(request);
+    return;
+  }
+  if (method == HTTP_GET && url == "/api/v1/diagnostics") {
+    handle_diagnostics_(request);
+    return;
+  }
+
+  if (method == HTTP_POST) {
+    std::string body = read_body_(request);
+    if (url == "/api/v1/power") { handle_power_(request, body); return; }
+    if (url == "/api/v1/mode") { handle_mode_(request, body); return; }
+    if (url == "/api/v1/fan") { handle_fan_(request, body); return; }
+    if (url == "/api/v1/setpoint") { handle_setpoint_(request, body); return; }
+
+    const std::string zones_prefix = "/api/v1/zones/";
+    if (url.rfind(zones_prefix, 0) == 0) {
+      // Accepts:
+      //   /api/v1/zones/{n}              — on/off + setpoint (Ultima)
+      //   /api/v1/zones/{n}/control      — claim/release wall-controller role
+      //   /api/v1/zones/{n}/temperature  — inject external sensor reading
+      const char *tail = url.c_str() + zones_prefix.size();
+      int zone = atoi(tail);
+      const char *slash = strchr(tail, '/');
+      if (slash == nullptr) {
+        handle_zone_(request, zone, body);
+        return;
+      }
+      std::string subpath(slash + 1);
+      if (subpath == "control") {
+        handle_zone_control_(request, zone, body);
+        return;
+      }
+      if (subpath == "temperature") {
+        handle_zone_temperature_(request, zone, body);
+        return;
+      }
+      send_error_(request, 404, "not_found");
+      return;
+    }
+  }
+
+  send_error_(request, 404, "not_found");
+}
+
+void Actron485ApiHandler::handle_info_(AsyncWebServerRequest *request) {
+  JsonDocument doc;
+  auto root = doc.to<JsonObject>();
+  root["device_name"] = App.get_name();
+  root["api_version"] = "v1";
+  root["esphome_version"] = ESPHOME_VERSION;
+  root["build_time"] = App.get_compilation_time();
+  root["has_ultima"] = parent_->climate()->has_ultima();
+  root["zone_count"] = 8;
+  root["uptime_ms"] = (unsigned long) millis();
+
+  std::string out;
+  serializeJson(doc, out);
+  send_json_(request, 200, out);
+}
+
+void Actron485ApiHandler::handle_state_(AsyncWebServerRequest *request) {
+  if (!parent_->controller()->receivingData()) {
+    send_error_(request, 409, "rs485_not_receiving");
+    return;
+  }
+  send_json_(request, 200, parent_->build_state_json());
+}
+
+void Actron485ApiHandler::handle_diagnostics_(AsyncWebServerRequest *request) {
+  auto *c = parent_->controller();
+  JsonDocument doc;
+  auto root = doc.to<JsonObject>();
+  root["receiving_data"] = c->receivingData();
+  root["data_last_received_ms"] = c->dataLastReceivedTime;
+  root["data_last_sent_ms"] = c->dataLastSentTime;
+  root["status_last_received_ms"] = c->statusLastReceivedTime;
+  root["pending_commands"] = c->totalPendingCommands();
+  root["pending_main_commands"] = c->totalPendingMainCommands();
+  root["uptime_ms"] = (unsigned long) millis();
+
+  std::string out;
+  serializeJson(doc, out);
+  send_json_(request, 200, out);
+}
+
+void Actron485ApiHandler::handle_power_(AsyncWebServerRequest *request, const std::string &body) {
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
+  if (!doc["on"].is<bool>()) { send_error_(request, 400, "missing_on"); return; }
+  parent_->controller()->setSystemOn(doc["on"].as<bool>());
+  send_json_(request, 202, "{\"status\":\"queued\"}");
+}
+
+void Actron485ApiHandler::handle_mode_(AsyncWebServerRequest *request, const std::string &body) {
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
+  const char *mode = doc["mode"] | (const char *) nullptr;
+  Actron485::OperatingMode op;
+  if (!string_to_operating_mode(mode, op)) { send_error_(request, 400, "invalid_mode"); return; }
+  parent_->controller()->setOperatingMode(op);
+  send_json_(request, 202, "{\"status\":\"queued\"}");
+}
+
+void Actron485ApiHandler::handle_fan_(AsyncWebServerRequest *request, const std::string &body) {
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
+  const char *speed = doc["speed"] | (const char *) nullptr;
+  if (speed != nullptr) {
+    Actron485::FanMode fan;
+    if (!string_to_fan_mode(speed, fan)) { send_error_(request, 400, "invalid_speed"); return; }
+    parent_->controller()->setFanSpeed(fan);
+  }
+  if (doc["continuous"].is<bool>()) {
+    parent_->controller()->setContinuousFanMode(doc["continuous"].as<bool>());
+  }
+  send_json_(request, 202, "{\"status\":\"queued\"}");
+}
+
+void Actron485ApiHandler::handle_setpoint_(AsyncWebServerRequest *request, const std::string &body) {
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
+  if (!doc["temperature"].is<float>() && !doc["temperature"].is<double>() && !doc["temperature"].is<int>()) {
+    send_error_(request, 400, "missing_temperature"); return;
+  }
+  double t = doc["temperature"].as<double>();
+  if (t < 16.0 || t > 30.0) { send_error_(request, 400, "temperature_out_of_range"); return; }
+  parent_->controller()->setMasterSetpoint(t);
+  send_json_(request, 202, "{\"status\":\"queued\"}");
+}
+
+void Actron485ApiHandler::handle_zone_(AsyncWebServerRequest *request, int zone, const std::string &body) {
+  if (zone < 1 || zone > 8) { send_error_(request, 400, "invalid_zone"); return; }
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
+
+  if (doc["on"].is<bool>()) {
+    parent_->controller()->setZoneOn((uint8_t) zone, doc["on"].as<bool>());
+  }
+  if (doc["setpoint"].is<float>() || doc["setpoint"].is<double>() || doc["setpoint"].is<int>()) {
+    if (!parent_->climate()->has_ultima()) {
+      send_error_(request, 400, "setpoint_requires_ultima"); return;
+    }
+    double t = doc["setpoint"].as<double>();
+    if (t < 16.0 || t > 30.0) { send_error_(request, 400, "setpoint_out_of_range"); return; }
+    parent_->controller()->setZoneSetpointTemperatureCustom((uint8_t) zone, t, false);
+  }
+  send_json_(request, 202, "{\"status\":\"queued\"}");
+}
+
+// POST /api/v1/zones/{n}/control  {"enabled": true}
+// Claims (true) or releases (false) the wall-controller role for the given
+// zone on the RS485 bus. Required before injected temperature readings will
+// be respected by the Actron master. Call once at startup per zone you plan
+// to feed external sensor data for.
+void Actron485ApiHandler::handle_zone_control_(AsyncWebServerRequest *request, int zone, const std::string &body) {
+  if (zone < 1 || zone > 8) { send_error_(request, 400, "invalid_zone"); return; }
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
+  if (!doc["enabled"].is<bool>()) { send_error_(request, 400, "missing_enabled"); return; }
+  parent_->controller()->setControlZone((uint8_t) zone, doc["enabled"].as<bool>());
+  send_json_(request, 202, "{\"status\":\"queued\"}");
+}
+
+// POST /api/v1/zones/{n}/temperature  {"current": 22.4}
+// Injects a sensor reading for the zone on behalf of a remote ESP32 sensor.
+// Only effective if /control was previously set enabled=true for this zone,
+// otherwise the Actron master ignores our reading.
+void Actron485ApiHandler::handle_zone_temperature_(AsyncWebServerRequest *request, int zone, const std::string &body) {
+  if (zone < 1 || zone > 8) { send_error_(request, 400, "invalid_zone"); return; }
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
+  if (!doc["current"].is<float>() && !doc["current"].is<double>() && !doc["current"].is<int>()) {
+    send_error_(request, 400, "missing_current"); return;
+  }
+  double t = doc["current"].as<double>();
+  // Wide bounds — not the AC's setpoint range; just sanity-checking the
+  // reading is plausibly room temperature in Celsius.
+  if (t < 0.0 || t > 60.0) { send_error_(request, 400, "temperature_out_of_range"); return; }
+  if (!parent_->controller()->getControlZone((uint8_t) zone)) {
+    ESP_LOGW(TAG, "Zone %d temperature set while not in control; call /control first", zone);
+  }
+  parent_->controller()->setZoneCurrentTemperature((uint8_t) zone, t);
+  parent_->note_zone_temperature_update((uint8_t) zone);
+  send_json_(request, 202, "{\"status\":\"queued\"}");
+}
+
+}  // namespace actron485_api
+}  // namespace esphome

--- a/components/actron485_api/actron485_api.cpp
+++ b/components/actron485_api/actron485_api.cpp
@@ -154,6 +154,81 @@ void Actron485Api::dump_config() {
   } else {
     ESP_LOGCONFIG(TAG, "  Sensor stale timeout: %u ms", sensor_stale_timeout_ms_);
   }
+  if (demo_mode_) {
+    ESP_LOGW(TAG, "  !!! DEMO MODE ENABLED — NOT connected to any AC !!!");
+    ESP_LOGW(TAG, "  !!! API returns simulated state; RS485 writes suppressed !!!");
+  }
+}
+
+// -------- Write wrappers: controller in normal mode, local state in demo --------
+
+void Actron485Api::apply_system_on(bool on) {
+  if (demo_mode_) { demo_system_on_ = on; return; }
+  controller()->setSystemOn(on);
+}
+void Actron485Api::apply_operating_mode(Actron485::OperatingMode mode) {
+  if (demo_mode_) { demo_op_mode_ = mode; return; }
+  controller()->setOperatingMode(mode);
+}
+void Actron485Api::apply_fan_speed(Actron485::FanMode mode) {
+  if (demo_mode_) { demo_fan_ = mode; return; }
+  controller()->setFanSpeed(mode);
+}
+void Actron485Api::apply_continuous_fan(bool on) {
+  if (demo_mode_) { demo_continuous_fan_ = on; return; }
+  controller()->setContinuousFanMode(on);
+}
+void Actron485Api::apply_master_setpoint(double temperature) {
+  if (demo_mode_) { demo_setpoint_ = (float) temperature; return; }
+  controller()->setMasterSetpoint(temperature);
+}
+void Actron485Api::apply_zone_on(uint8_t zone, bool on) {
+  if (zone < 1 || zone > 8) return;
+  if (demo_mode_) { demo_zone_on_[zone - 1] = on; return; }
+  controller()->setZoneOn(zone, on);
+}
+void Actron485Api::apply_zone_setpoint(uint8_t zone, double temperature) {
+  if (zone < 1 || zone > 8) return;
+  if (demo_mode_) { demo_zone_setpoint_[zone - 1] = (float) temperature; return; }
+  controller()->setZoneSetpointTemperatureCustom(zone, temperature, false);
+}
+void Actron485Api::apply_zone_control(uint8_t zone, bool enabled) {
+  if (zone < 1 || zone > 8) return;
+  if (demo_mode_) { demo_zone_control_[zone - 1] = enabled; return; }
+  controller()->setControlZone(zone, enabled);
+}
+void Actron485Api::apply_zone_current_temperature(uint8_t zone, double temperature) {
+  if (zone < 1 || zone > 8) return;
+  if (demo_mode_) { demo_zone_current_[zone - 1] = (float) temperature; return; }
+  controller()->setZoneCurrentTemperature(zone, temperature);
+}
+
+bool Actron485Api::state_receiving_data() {
+  if (demo_mode_) return true;
+  return controller()->receivingData();
+}
+
+// Drift zone currents toward their setpoints (or toward master setpoint if the
+// zone has no setpoint set / isn't controlled), so the mobile app sees live-ish
+// movement in demo mode. Master current is the mean of zone currents.
+void Actron485Api::demo_tick_() {
+  unsigned long now = millis();
+  if (demo_last_tick_ms_ == 0) { demo_last_tick_ms_ = now; return; }
+  float dt = (now - demo_last_tick_ms_) / 1000.0f;
+  demo_last_tick_ms_ = now;
+  if (dt <= 0) return;
+
+  const float rate = 0.05f;  // °C per second toward target
+  float sum = 0;
+  for (int i = 0; i < 8; i++) {
+    float target = demo_zone_setpoint_[i];
+    if (!demo_system_on_) target = 20.0f + (i * 0.1f);  // ambient drift when off
+    float delta = target - demo_zone_current_[i];
+    float step = std::max(-rate * dt, std::min(rate * dt, delta));
+    demo_zone_current_[i] += step;
+    sum += demo_zone_current_[i];
+  }
+  demo_current_ = sum / 8.0f;
 }
 
 void Actron485Api::note_zone_temperature_update(uint8_t zone) {
@@ -167,6 +242,10 @@ void Actron485Api::note_zone_temperature_update(uint8_t zone) {
 }
 
 void Actron485Api::loop() {
+  if (demo_mode_) {
+    this->demo_tick_();
+    return;  // nothing else to do — the real bus isn't in play
+  }
   if (sensor_stale_timeout_ms_ == 0) return;
   unsigned long now = millis();
   // Check at most once per second — cheap but avoids per-tick overhead.
@@ -188,35 +267,72 @@ void Actron485Api::loop() {
 }
 
 std::string Actron485Api::build_state_json() {
-  auto *c = controller();
   JsonDocument doc;
   auto root = doc.to<JsonObject>();
 
   // Monotonic ms since boot; the mobile app can compute freshness by diffing
   // two snapshots' updated_at_ms or comparing to its own request clock.
   root["updated_at_ms"] = (unsigned long) millis();
-  root["status_received_ms"] = c->statusLastReceivedTime;
-  root["system_on"] = c->getSystemOn();
-  root["mode"] = operating_mode_to_string(c->getOperatingMode());
-  root["fan"] = fan_mode_to_string(c->getFanSpeed());
-  root["fan_running"] = fan_mode_to_string(c->getRunningFanSpeed());
-  root["continuous_fan"] = c->getContinuousFanMode();
-  root["compressor"] = compressor_to_string(c->getCompressorMode());
-  root["setpoint"] = c->getMasterSetpoint();
-  root["current_temperature"] = c->getMasterCurrentTemperature();
-  root["has_ultima"] = climate_->has_ultima();
 
-  JsonArray zones = root["zones"].to<JsonArray>();
-  for (int i = 1; i <= 8; i++) {
-    JsonObject z = zones.add<JsonObject>();
-    z["number"] = i;
-    z["name"] = this->get_zone_display_name(i);
-    z["on"] = c->getZoneOn(i);
-    z["damper"] = c->getZoneDamperPosition(i);
-    z["control"] = c->getControlZone(i);
-    if (climate_->has_ultima()) {
-      z["setpoint"] = c->getZoneSetpointTemperature(i);
-      z["current_temperature"] = c->getZoneCurrentTemperature(i);
+  if (demo_mode_) {
+    root["status_received_ms"] = (unsigned long) millis();
+    root["system_on"] = demo_system_on_;
+    root["mode"] = operating_mode_to_string(demo_op_mode_);
+    root["fan"] = fan_mode_to_string(demo_fan_);
+    root["fan_running"] = fan_mode_to_string(demo_fan_);
+    root["continuous_fan"] = demo_continuous_fan_;
+    // Very simple "compressor" rule — if the system is on and in a thermal
+    // mode, report the appropriate direction. Good enough to exercise
+    // status/action indicators in the app.
+    const char *compressor = "idle";
+    if (demo_system_on_) {
+      if (demo_op_mode_ == Actron485::OperatingMode::Cool) compressor = "cooling";
+      else if (demo_op_mode_ == Actron485::OperatingMode::Heat) compressor = "heating";
+    }
+    root["compressor"] = compressor;
+    root["setpoint"] = demo_setpoint_;
+    root["current_temperature"] = demo_current_;
+    root["has_ultima"] = climate_->has_ultima();
+    root["demo"] = true;
+
+    JsonArray zones = root["zones"].to<JsonArray>();
+    for (int i = 1; i <= 8; i++) {
+      JsonObject z = zones.add<JsonObject>();
+      z["number"] = i;
+      z["name"] = this->get_zone_display_name(i);
+      z["on"] = demo_zone_on_[i - 1];
+      z["damper"] = demo_zone_on_[i - 1] ? 1.0 : 0.0;
+      z["control"] = demo_zone_control_[i - 1];
+      if (climate_->has_ultima()) {
+        z["setpoint"] = demo_zone_setpoint_[i - 1];
+        z["current_temperature"] = demo_zone_current_[i - 1];
+      }
+    }
+  } else {
+    auto *c = controller();
+    root["status_received_ms"] = c->statusLastReceivedTime;
+    root["system_on"] = c->getSystemOn();
+    root["mode"] = operating_mode_to_string(c->getOperatingMode());
+    root["fan"] = fan_mode_to_string(c->getFanSpeed());
+    root["fan_running"] = fan_mode_to_string(c->getRunningFanSpeed());
+    root["continuous_fan"] = c->getContinuousFanMode();
+    root["compressor"] = compressor_to_string(c->getCompressorMode());
+    root["setpoint"] = c->getMasterSetpoint();
+    root["current_temperature"] = c->getMasterCurrentTemperature();
+    root["has_ultima"] = climate_->has_ultima();
+
+    JsonArray zones = root["zones"].to<JsonArray>();
+    for (int i = 1; i <= 8; i++) {
+      JsonObject z = zones.add<JsonObject>();
+      z["number"] = i;
+      z["name"] = this->get_zone_display_name(i);
+      z["on"] = c->getZoneOn(i);
+      z["damper"] = c->getZoneDamperPosition(i);
+      z["control"] = c->getControlZone(i);
+      if (climate_->has_ultima()) {
+        z["setpoint"] = c->getZoneSetpointTemperature(i);
+        z["current_temperature"] = c->getZoneCurrentTemperature(i);
+      }
     }
   }
 
@@ -385,6 +501,7 @@ void Actron485ApiHandler::handle_info_(AsyncWebServerRequest *request) {
   root["has_ultima"] = parent_->climate()->has_ultima();
   root["zone_count"] = 8;
   root["uptime_ms"] = (unsigned long) millis();
+  root["demo"] = parent_->demo_mode();
   // Static zone metadata — safe to return even when the RS485 bus is silent.
   JsonArray zones = root["zones"].to<JsonArray>();
   for (int i = 1; i <= 8; i++) {
@@ -399,7 +516,7 @@ void Actron485ApiHandler::handle_info_(AsyncWebServerRequest *request) {
 }
 
 void Actron485ApiHandler::handle_state_(AsyncWebServerRequest *request) {
-  if (!parent_->controller()->receivingData()) {
+  if (!parent_->state_receiving_data()) {
     send_error_(request, 409, "rs485_not_receiving");
     return;
   }
@@ -407,15 +524,25 @@ void Actron485ApiHandler::handle_state_(AsyncWebServerRequest *request) {
 }
 
 void Actron485ApiHandler::handle_diagnostics_(AsyncWebServerRequest *request) {
-  auto *c = parent_->controller();
   JsonDocument doc;
   auto root = doc.to<JsonObject>();
-  root["receiving_data"] = c->receivingData();
-  root["data_last_received_ms"] = c->dataLastReceivedTime;
-  root["data_last_sent_ms"] = c->dataLastSentTime;
-  root["status_last_received_ms"] = c->statusLastReceivedTime;
-  root["pending_commands"] = c->totalPendingCommands();
-  root["pending_main_commands"] = c->totalPendingMainCommands();
+  root["demo"] = parent_->demo_mode();
+  if (parent_->demo_mode()) {
+    root["receiving_data"] = true;
+    root["data_last_received_ms"] = (unsigned long) millis();
+    root["data_last_sent_ms"] = (unsigned long) millis();
+    root["status_last_received_ms"] = (unsigned long) millis();
+    root["pending_commands"] = 0;
+    root["pending_main_commands"] = 0;
+  } else {
+    auto *c = parent_->controller();
+    root["receiving_data"] = c->receivingData();
+    root["data_last_received_ms"] = c->dataLastReceivedTime;
+    root["data_last_sent_ms"] = c->dataLastSentTime;
+    root["status_last_received_ms"] = c->statusLastReceivedTime;
+    root["pending_commands"] = c->totalPendingCommands();
+    root["pending_main_commands"] = c->totalPendingMainCommands();
+  }
   root["uptime_ms"] = (unsigned long) millis();
 
   std::string out;
@@ -427,7 +554,7 @@ void Actron485ApiHandler::handle_power_(AsyncWebServerRequest *request, const st
   JsonDocument doc;
   if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
   if (!doc["on"].is<bool>()) { send_error_(request, 400, "missing_on"); return; }
-  parent_->controller()->setSystemOn(doc["on"].as<bool>());
+  parent_->apply_system_on(doc["on"].as<bool>());
   send_json_(request, 202, "{\"status\":\"queued\"}");
 }
 
@@ -437,7 +564,7 @@ void Actron485ApiHandler::handle_mode_(AsyncWebServerRequest *request, const std
   const char *mode = doc["mode"] | (const char *) nullptr;
   Actron485::OperatingMode op;
   if (!string_to_operating_mode(mode, op)) { send_error_(request, 400, "invalid_mode"); return; }
-  parent_->controller()->setOperatingMode(op);
+  parent_->apply_operating_mode(op);
   send_json_(request, 202, "{\"status\":\"queued\"}");
 }
 
@@ -448,10 +575,10 @@ void Actron485ApiHandler::handle_fan_(AsyncWebServerRequest *request, const std:
   if (speed != nullptr) {
     Actron485::FanMode fan;
     if (!string_to_fan_mode(speed, fan)) { send_error_(request, 400, "invalid_speed"); return; }
-    parent_->controller()->setFanSpeed(fan);
+    parent_->apply_fan_speed(fan);
   }
   if (doc["continuous"].is<bool>()) {
-    parent_->controller()->setContinuousFanMode(doc["continuous"].as<bool>());
+    parent_->apply_continuous_fan(doc["continuous"].as<bool>());
   }
   send_json_(request, 202, "{\"status\":\"queued\"}");
 }
@@ -464,7 +591,7 @@ void Actron485ApiHandler::handle_setpoint_(AsyncWebServerRequest *request, const
   }
   double t = doc["temperature"].as<double>();
   if (t < 16.0 || t > 30.0) { send_error_(request, 400, "temperature_out_of_range"); return; }
-  parent_->controller()->setMasterSetpoint(t);
+  parent_->apply_master_setpoint(t);
   send_json_(request, 202, "{\"status\":\"queued\"}");
 }
 
@@ -474,7 +601,7 @@ void Actron485ApiHandler::handle_zone_(AsyncWebServerRequest *request, int zone,
   if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
 
   if (doc["on"].is<bool>()) {
-    parent_->controller()->setZoneOn((uint8_t) zone, doc["on"].as<bool>());
+    parent_->apply_zone_on((uint8_t) zone, doc["on"].as<bool>());
   }
   if (doc["setpoint"].is<float>() || doc["setpoint"].is<double>() || doc["setpoint"].is<int>()) {
     if (!parent_->climate()->has_ultima()) {
@@ -482,7 +609,7 @@ void Actron485ApiHandler::handle_zone_(AsyncWebServerRequest *request, int zone,
     }
     double t = doc["setpoint"].as<double>();
     if (t < 16.0 || t > 30.0) { send_error_(request, 400, "setpoint_out_of_range"); return; }
-    parent_->controller()->setZoneSetpointTemperatureCustom((uint8_t) zone, t, false);
+    parent_->apply_zone_setpoint((uint8_t) zone, t);
   }
   send_json_(request, 202, "{\"status\":\"queued\"}");
 }
@@ -497,7 +624,7 @@ void Actron485ApiHandler::handle_zone_control_(AsyncWebServerRequest *request, i
   JsonDocument doc;
   if (deserializeJson(doc, body)) { send_error_(request, 400, "invalid_json"); return; }
   if (!doc["enabled"].is<bool>()) { send_error_(request, 400, "missing_enabled"); return; }
-  parent_->controller()->setControlZone((uint8_t) zone, doc["enabled"].as<bool>());
+  parent_->apply_zone_control((uint8_t) zone, doc["enabled"].as<bool>());
   send_json_(request, 202, "{\"status\":\"queued\"}");
 }
 
@@ -516,10 +643,13 @@ void Actron485ApiHandler::handle_zone_temperature_(AsyncWebServerRequest *reques
   // Wide bounds — not the AC's setpoint range; just sanity-checking the
   // reading is plausibly room temperature in Celsius.
   if (t < 0.0 || t > 60.0) { send_error_(request, 400, "temperature_out_of_range"); return; }
-  if (!parent_->controller()->getControlZone((uint8_t) zone)) {
+  bool controlled = parent_->demo_mode()
+                       ? false  // demo: just accept the reading
+                       : parent_->controller()->getControlZone((uint8_t) zone);
+  if (!parent_->demo_mode() && !controlled) {
     ESP_LOGW(TAG, "Zone %d temperature set while not in control; call /control first", zone);
   }
-  parent_->controller()->setZoneCurrentTemperature((uint8_t) zone, t);
+  parent_->apply_zone_current_temperature((uint8_t) zone, t);
   parent_->note_zone_temperature_update((uint8_t) zone);
   send_json_(request, 202, "{\"status\":\"queued\"}");
 }

--- a/components/actron485_api/actron485_api.h
+++ b/components/actron485_api/actron485_api.h
@@ -122,6 +122,7 @@ class Actron485ApiHandler : public AsyncWebHandler {
   void handle_info_(AsyncWebServerRequest *request);
   void handle_state_(AsyncWebServerRequest *request);
   void handle_diagnostics_(AsyncWebServerRequest *request);
+  void handle_demo_(AsyncWebServerRequest *request, const std::string &body);
   void handle_power_(AsyncWebServerRequest *request, const std::string &body);
   void handle_mode_(AsyncWebServerRequest *request, const std::string &body);
   void handle_fan_(AsyncWebServerRequest *request, const std::string &body);

--- a/components/actron485_api/actron485_api.h
+++ b/components/actron485_api/actron485_api.h
@@ -88,6 +88,15 @@ class Actron485Api : public Component {
   float demo_zone_current_[8]{21.4f, 21.4f, 21.4f, 21.4f, 21.4f, 21.4f, 21.4f, 21.4f};
   unsigned long demo_last_tick_ms_{0};
   unsigned long demo_last_publish_ms_{0};
+  // "Last value we wrote into the Climate/fan entities from demo_tick".
+  // Used at the next tick to detect web-UI-driven changes (where the
+  // current climate_ value differs from what we last pushed) vs
+  // API-driven changes (where demo_* diverges but climate_ is unchanged).
+  float demo_last_pub_setpoint_{NAN};
+  int demo_last_pub_mode_{-1};
+  int demo_last_pub_fan_{-1};
+  bool demo_last_pub_zone_on_[8]{};
+  float demo_last_pub_zone_setpoint_[8]{NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN};
   void demo_tick_();
 
   // Zone name overrides persisted to flash via ESPHome preferences.

--- a/components/actron485_api/actron485_api.h
+++ b/components/actron485_api/actron485_api.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <string>
+
+#include "esphome/core/component.h"
+#include "esphome/components/web_server_base/web_server_base.h"
+#include "esphome/components/actron485/actron485_climate.h"
+#include "Actron485.h"
+
+namespace esphome {
+namespace actron485_api {
+
+class Actron485ApiHandler;  // fwd
+
+class Actron485Api : public Component {
+ public:
+  void set_climate(actron485::Actron485Climate *climate) { climate_ = climate; }
+  void set_auth_token(const std::string &token) { auth_token_ = token; }
+  void set_sensor_stale_timeout_ms(uint32_t ms) { sensor_stale_timeout_ms_ = ms; }
+
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+
+  // Called by the temperature handler on each successful POST.
+  void note_zone_temperature_update(uint8_t zone);
+
+  Actron485::Controller *controller() { return climate_->get_controller(); }
+  actron485::Actron485Climate *climate() { return climate_; }
+  const std::string &auth_token() const { return auth_token_; }
+
+  // Serialized state snapshot used by both GET /state and (future) streaming.
+  std::string build_state_json();
+
+ protected:
+  actron485::Actron485Climate *climate_{nullptr};
+  std::string auth_token_;  // empty = no auth
+  Actron485ApiHandler *handler_{nullptr};
+
+  // Stale-sensor safety. last_temp_update_ms_[i] == 0 means we've never
+  // received a /temperature POST for that zone, so the watchdog ignores it.
+  uint32_t sensor_stale_timeout_ms_{600000};
+  unsigned long last_temp_update_ms_[8]{};
+  unsigned long last_stale_check_ms_{0};
+};
+
+class Actron485ApiHandler : public AsyncWebHandler {
+ public:
+  explicit Actron485ApiHandler(Actron485Api *parent) : parent_(parent) {}
+
+  bool canHandle(AsyncWebServerRequest *request) const override;
+  void handleRequest(AsyncWebServerRequest *request) override;
+  bool isRequestHandlerTrivial() const override { return false; }
+
+ protected:
+  Actron485Api *parent_;
+
+  bool authorized_(AsyncWebServerRequest *request);
+  std::string read_body_(AsyncWebServerRequest *request);
+
+  void send_json_(AsyncWebServerRequest *request, int code, const std::string &body);
+  void send_error_(AsyncWebServerRequest *request, int code, const char *message);
+  void add_cors_headers_(AsyncWebServerResponse *response);
+
+  void handle_info_(AsyncWebServerRequest *request);
+  void handle_state_(AsyncWebServerRequest *request);
+  void handle_diagnostics_(AsyncWebServerRequest *request);
+  void handle_power_(AsyncWebServerRequest *request, const std::string &body);
+  void handle_mode_(AsyncWebServerRequest *request, const std::string &body);
+  void handle_fan_(AsyncWebServerRequest *request, const std::string &body);
+  void handle_setpoint_(AsyncWebServerRequest *request, const std::string &body);
+  void handle_zone_(AsyncWebServerRequest *request, int zone, const std::string &body);
+  void handle_zone_control_(AsyncWebServerRequest *request, int zone, const std::string &body);
+  void handle_zone_temperature_(AsyncWebServerRequest *request, int zone, const std::string &body);
+};
+
+}  // namespace actron485_api
+}  // namespace esphome

--- a/components/actron485_api/actron485_api.h
+++ b/components/actron485_api/actron485_api.h
@@ -18,6 +18,8 @@ class Actron485Api : public Component {
   void set_climate(actron485::Actron485Climate *climate) { climate_ = climate; }
   void set_auth_token(const std::string &token) { auth_token_ = token; }
   void set_sensor_stale_timeout_ms(uint32_t ms) { sensor_stale_timeout_ms_ = ms; }
+  void set_demo_mode(bool on) { demo_mode_ = on; }
+  bool demo_mode() const { return demo_mode_; }
 
   void setup() override;
   void loop() override;
@@ -43,6 +45,22 @@ class Actron485Api : public Component {
   // Serialized state snapshot used by both GET /state and (future) streaming.
   std::string build_state_json();
 
+  // Write-path wrappers. In normal mode these delegate to the Actron485
+  // controller. In demo mode they mutate only the simulator's state and
+  // never touch the RS485 bus.
+  void apply_system_on(bool on);
+  void apply_operating_mode(Actron485::OperatingMode mode);
+  void apply_fan_speed(Actron485::FanMode mode);
+  void apply_continuous_fan(bool on);
+  void apply_master_setpoint(double temperature);
+  void apply_zone_on(uint8_t zone, bool on);
+  void apply_zone_setpoint(uint8_t zone, double temperature);
+  void apply_zone_control(uint8_t zone, bool enabled);
+  void apply_zone_current_temperature(uint8_t zone, double temperature);
+
+  // State accessor that respects demo mode.
+  bool state_receiving_data();
+
  protected:
   actron485::Actron485Climate *climate_{nullptr};
   std::string auth_token_;  // empty = no auth
@@ -53,6 +71,23 @@ class Actron485Api : public Component {
   uint32_t sensor_stale_timeout_ms_{600000};
   unsigned long last_temp_update_ms_[8]{};
   unsigned long last_stale_check_ms_{0};
+
+  // ---- Demo-mode simulation state ----
+  // Only used when demo_mode_ is true. On a real device these are all
+  // ignored and the Actron485 controller owns the state.
+  bool demo_mode_{false};
+  bool demo_system_on_{false};
+  Actron485::OperatingMode demo_op_mode_{Actron485::OperatingMode::Off};
+  Actron485::FanMode demo_fan_{Actron485::FanMode::Esp};
+  bool demo_continuous_fan_{false};
+  float demo_setpoint_{22.0f};
+  float demo_current_{21.4f};
+  bool demo_zone_on_[8]{};
+  bool demo_zone_control_[8]{};
+  float demo_zone_setpoint_[8]{22.0f, 22.0f, 22.0f, 22.0f, 22.0f, 22.0f, 22.0f, 22.0f};
+  float demo_zone_current_[8]{21.4f, 21.4f, 21.4f, 21.4f, 21.4f, 21.4f, 21.4f, 21.4f};
+  unsigned long demo_last_tick_ms_{0};
+  void demo_tick_();
 
   // Zone name overrides persisted to flash via ESPHome preferences.
   // Empty string means "no override; use the ESPHome entity name".

--- a/components/actron485_api/actron485_api.h
+++ b/components/actron485_api/actron485_api.h
@@ -87,6 +87,7 @@ class Actron485Api : public Component {
   float demo_zone_setpoint_[8]{22.0f, 22.0f, 22.0f, 22.0f, 22.0f, 22.0f, 22.0f, 22.0f};
   float demo_zone_current_[8]{21.4f, 21.4f, 21.4f, 21.4f, 21.4f, 21.4f, 21.4f, 21.4f};
   unsigned long demo_last_tick_ms_{0};
+  unsigned long demo_last_publish_ms_{0};
   void demo_tick_();
 
   // Zone name overrides persisted to flash via ESPHome preferences.

--- a/components/actron485_api/actron485_api.h
+++ b/components/actron485_api/actron485_api.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
 #include "esphome/components/web_server_base/web_server_base.h"
 #include "esphome/components/actron485/actron485_climate.h"
 #include "Actron485.h"
@@ -26,6 +27,15 @@ class Actron485Api : public Component {
   // Called by the temperature handler on each successful POST.
   void note_zone_temperature_update(uint8_t zone);
 
+  // Returns the display name for a zone (1..8): override (if set) > ESPHome
+  // entity name > "Zone N".
+  std::string get_zone_display_name(int zone);
+
+  // Persists an override name for a zone. Empty string clears the override
+  // (the ESPHome entity name is used again). Returns false if zone is
+  // out of range or the name is too long.
+  bool set_zone_name_override(uint8_t zone, const std::string &name);
+
   Actron485::Controller *controller() { return climate_->get_controller(); }
   actron485::Actron485Climate *climate() { return climate_; }
   const std::string &auth_token() const { return auth_token_; }
@@ -43,6 +53,17 @@ class Actron485Api : public Component {
   uint32_t sensor_stale_timeout_ms_{600000};
   unsigned long last_temp_update_ms_[8]{};
   unsigned long last_stale_check_ms_{0};
+
+  // Zone name overrides persisted to flash via ESPHome preferences.
+  // Empty string means "no override; use the ESPHome entity name".
+  static constexpr size_t ZONE_NAME_MAX = 31;
+  struct ZoneNamesBlob {
+    char names[8][ZONE_NAME_MAX + 1];
+  };
+  std::string zone_name_overrides_[8];
+  ESPPreferenceObject zone_names_pref_;
+  void load_zone_names_();
+  void save_zone_names_();
 };
 
 class Actron485ApiHandler : public AsyncWebHandler {
@@ -73,6 +94,7 @@ class Actron485ApiHandler : public AsyncWebHandler {
   void handle_zone_(AsyncWebServerRequest *request, int zone, const std::string &body);
   void handle_zone_control_(AsyncWebServerRequest *request, int zone, const std::string &body);
   void handle_zone_temperature_(AsyncWebServerRequest *request, int zone, const std::string &body);
+  void handle_zone_name_(AsyncWebServerRequest *request, int zone, const std::string &body);
 };
 
 }  // namespace actron485_api

--- a/src/Actron485.cpp
+++ b/src/Actron485.cpp
@@ -550,15 +550,24 @@ namespace Actron485 {
             bytesRead++;
             _serialBufferReceivedTime = platformMillis();
 
-            if (_serialBufferIndex == 1) {
-                MessageType messageType = detectActronMessageType(_serialBuffer[0]);
-                _serialBufferExpectedLength = expectedActronMessageLength(messageType);
+            MessageType firstByteType = MessageType::Unknown;
+            if (_serialBufferIndex >= 1) {
+                firstByteType = detectActronMessageType(_serialBuffer[0]);
             }
 
-            uint8_t modbusLength = expectedModbusMessageLength();
-            if (modbusLength > 0 && (_serialBufferExpectedLength == 0 || modbusLength > _serialBufferExpectedLength)) {
-                // Allow variable-length Modbus responses (0x03/0x04/0x10) to grow once byte_count arrives.
-                _serialBufferExpectedLength = modbusLength;
+            if (_serialBufferIndex == 1) {
+                _serialBufferExpectedLength = expectedActronMessageLength(firstByteType);
+            }
+
+            // Only fall through to Modbus framing if the first byte didn't already match a known
+            // Actron message type. Several Actron types (notably IndoorBoard1 = 0x01) collide with
+            // valid Modbus slave addresses, and their second byte can match a Modbus function code,
+            // which would otherwise cause Modbus framing to chop the Actron frame in half.
+            if (firstByteType == MessageType::Unknown) {
+                uint8_t modbusLength = expectedModbusMessageLength();
+                if (modbusLength > 0 && (_serialBufferExpectedLength == 0 || modbusLength > _serialBufferExpectedLength)) {
+                    _serialBufferExpectedLength = modbusLength;
+                }
             }
 
             if (_serialBufferExpectedLength > 0 && _serialBufferIndex >= _serialBufferExpectedLength) {


### PR DESCRIPTION
## Summary
- The byte-stream parser unconditionally let Modbus length take precedence whenever it produced a non-zero estimate. This silently chopped genuine Actron frames in half when the first byte happened to be a valid Modbus slave address (notably `IndoorBoard1 = 0x01`) and the second byte matched a Modbus function code.
- Symptom seen on a real Que master: an indoor broadcast frame `01 10 01 22 00 06 …` was treated as a `9 + byte_count` Modbus Write Multiple Registers request, flushed early, and the remainder began a phantom `0B 10 …` read request — leaving `StateMessage` / `StateMessage2` unparsed and the `actron485_api` `/state` endpoint frozen.
- Fix: only fall through to Modbus framing when the first byte didn't already match a known Actron message type.

## Test plan
- [ ] Flash the firmware against a Que master and confirm `State Message 2` / `Stat Message 1` parses succeed in `[D]` logs.
- [ ] Confirm the spurious `Modbus Message Ignored: 0B 10 …` lines (tails of split Indoor Board frames) disappear.
- [ ] Confirm `/api/v1/state` reflects current temperature changes within a few seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)